### PR TITLE
Update artifactory url

### DIFF
--- a/jenkins/packer-vm-configuration.json
+++ b/jenkins/packer-vm-configuration.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "source_url": "https://artifactory01.esss.lu.se:443/artifactory/swi-pkg/virtualbox/1708.02/esss-centos-7.ova",
+    "source_url": "https://artifactory.esss.lu.se/artifactory/swi-pkg/virtualbox/1708.02/esss-centos-7.ova",
     "description": "ESS DevEnv Vagrant base box based on CentOS 7"
   },
   "builders": [

--- a/linux-vm/css-update.sh
+++ b/linux-vm/css-update.sh
@@ -28,12 +28,12 @@ elif [ $# -lt 2 ]; then
     print_usage
   else
     NEW_VERSION=$1
-    wget "https://artifactory01.esss.lu.se:443/artifactory/CS-Studio/production/$NEW_VERSION/cs-studio-ess-$NEW_VERSION-linux.gtk.x86_64.tar.gz"
+    wget "https://artifactory.esss.lu.se/artifactory/CS-Studio/production/$NEW_VERSION/cs-studio-ess-$NEW_VERSION-linux.gtk.x86_64.tar.gz"
   fi
 else
   if [ "$1" == '-d' ]; then
     NEW_VERSION=$2
-    wget "https://artifactory01.esss.lu.se:443/artifactory/CS-Studio/development/$NEW_VERSION/cs-studio-ess-$NEW_VERSION-linux.gtk.x86_64.tar.gz"
+    wget "https://artifactory.esss.lu.se/artifactory/CS-Studio/development/$NEW_VERSION/cs-studio-ess-$NEW_VERSION-linux.gtk.x86_64.tar.gz"
   else
     print_usage
   fi


### PR DESCRIPTION
Artifactory was migrated to a new server (artifactory02).
The URL to use is artifactory.esss.lu.se which is a CNAME so that
migration is transparent.