### PR TITLE
Implement retention policy for dev in Artifactory

### DIFF
--- a/jenkins/css-pipeline
+++ b/jenkins/css-pipeline
@@ -173,12 +173,16 @@ pipeline {
           }
         }
       }
-      stage('00900\ndeploy build information and retent old builds') {
+      stage('00900\ndeploy build information and purge old builds') {
         when {
           expression { env.repoBranch != 'production' }
         }
         steps {
           buildInfo.retention maxBuilds: 7
+          buildInfo.env.filter.addInclude("BUILD*")
+          buildInfo.env.filter.addInclude("EPICS*")
+          buildInfo.env.filter.addInclude("JAVA_HOME")
+          buildInfo.env.collect()
           server.publishBuildInfo(buildInfo)
         }
       }

--- a/jenkins/css-pipeline
+++ b/jenkins/css-pipeline
@@ -1,4 +1,6 @@
 #!groovy​
+def server = Artifactory.server "${env.artifacoryServerID}"
+def buildInfo = Artifactory.newBuildInfo()
 pipeline {
 
   /*
@@ -153,7 +155,6 @@ pipeline {
         }
         steps{
           script {
-            def server = Artifactory.server "${env.artifacoryServerID}"
             def versionNBR = sh (script: """cat ${env.WORKSPACE}/org.csstudio.ess.product/features/org.csstudio.ess.product.configuration.feature/rootfiles/ess-version.txt""", returnStdout: true).trim()
             def uploadSpec = """{
             "files": [
@@ -167,14 +168,20 @@ pipeline {
             }
             ]
             }"""
-            server.upload(uploadSpec)
+            server.upload(uploadSpec, buildInfo)
             slackSend channel: "#cs-studio", message: "CS-Studio ver. ${versionNBR} loaded into Artifactory at ${artifactoryFolder}."
           }
         }
       }
-
-
-
+      stage('00900\ndeploy build information and retent old builds') {
+        when {
+          expression { env.repoBranch != 'production' }
+        }
+        steps {
+          buildInfo.retention maxBuilds: 7
+          server.publishBuildInfo(buildInfo)
+        }
+      }
     }
 
     /*


### PR DESCRIPTION
The retention policy is coupled with the build information so we need to
enable the creation of Builds for CS Studio in Artifactory as well.
This should have the nice side effect that you will now have a way to
browse which files have been uploaded to gether as artifacts from the
same build in Jenkins.

JIRA INFRA-462 #action Review